### PR TITLE
hide nametags for hidden avatars

### DIFF
--- a/scene/src/components/avatar-tags/avatar-name-tag-3d.tsx
+++ b/scene/src/components/avatar-tags/avatar-name-tag-3d.tsx
@@ -76,7 +76,11 @@ export async function initAvatarTags(): Promise<void> {
     if (!pressed) return
     state.hideNames = !state.hideNames
     addressTagEntitiesMap.forEach((entity) => {
-      VisibilityComponent.getMutable(entity).visible = !state.hideNames
+      if (state.hideNames) {
+        VisibilityComponent.createOrReplace(entity, { visible: false })
+      } else {
+        VisibilityComponent.deleteFrom(entity) // inherit
+      }
     })
   })
 }
@@ -112,7 +116,6 @@ function createTag(player: GetPlayerDataRes): undefined | Entity {
     tagWrapperEntity,
     getTagElement({ userId: player.userId as Address })
   )
-  VisibilityComponent.create(tagWrapperEntity, { visible: true })
 
   Material.setPbrMaterial(tagWrapperEntity, {
     transparencyMode: MaterialTransparencyMode.MTM_ALPHA_BLEND,


### PR DESCRIPTION
currently when avatars are hidden (via `AvatarModifierArea`s) the nametags are still visible because they explicitly set `VisibilityComponent { visible: true }`.

modify to only add VisibilityComponent when we are hiding the nametags, and remove it otherwise to fall back to parent avatar visibility