### PR TITLE
Respect AvatarModifierArea passport blocking

### DIFF
--- a/scene/src/bevy-api/interface.ts
+++ b/scene/src/bevy-api/interface.ts
@@ -210,6 +210,9 @@ export type BevyApiInterface = {
   }) => void
   setMicEnabled: (enabled: boolean) => void
   getMicState: () => Promise<{ enabled: boolean; available: boolean }>
+  getAvatarModifiers: () => Promise<
+    Array<{ userId: string; hideAvatar: boolean; hideProfile: boolean }>
+  >
 }
 
 // system api module

--- a/scene/src/service/avatar-tracker.ts
+++ b/scene/src/service/avatar-tracker.ts
@@ -61,10 +61,7 @@ export const createOrGetAvatarsTracker = (): AvatarTracker => {
       !avatarProxies.has(playerIdentity.address) &&
       playerIdentity.address !== getPlayer()?.userId
     ) {
-      const proxy = createAvatarProxy(
-        playerIdentity.address,
-        playerEntity
-      )
+      const proxy = createAvatarProxy(playerIdentity.address, playerEntity)
       avatarProxies.set(playerIdentity.address, proxy)
     }
   }
@@ -83,10 +80,7 @@ export const createOrGetAvatarsTracker = (): AvatarTracker => {
     }
 
     if (!avatarProxies.has(player.userId) && playerEntity) {
-      const proxy = createAvatarProxy(
-        player.userId,
-        playerEntity
-      )
+      const proxy = createAvatarProxy(player.userId, playerEntity)
       avatarProxies.set(player.userId, proxy)
     }
     callbacks.onEnterScene.forEach((fn) => {
@@ -210,10 +204,7 @@ export const createOrGetAvatarsTracker = (): AvatarTracker => {
     )
   }
 
-  function createAvatarProxy(
-    userId: string,
-    playerEntity: Entity
-  ): Entity {
+  function createAvatarProxy(userId: string, playerEntity: Entity): Entity {
     registerPointerDown(userId, playerEntity, false)
     return playerEntity
   }

--- a/scene/src/service/avatar-tracker.ts
+++ b/scene/src/service/avatar-tracker.ts
@@ -5,9 +5,11 @@ import {
   pointerEventsSystem,
   InputAction,
   type PBPointerEventsResult,
-  PlayerIdentityData
+  PlayerIdentityData,
+  executeTask
 } from '@dcl/sdk/ecs'
 import { onEnterScene, onLeaveScene, getPlayer } from '@dcl/sdk/players'
+import { BevyApi } from '../bevy-api'
 import {
   type PBAvatarBase,
   type PBAvatarEquippedData,
@@ -33,6 +35,7 @@ export type AvatarTracker = {
   onClick: (fn: UserIdCallback) => UnListenFn
   onEnterScene: (fn: PlayerCallback) => UnListenFn
   onLeaveScene: (fn: UserIdCallback) => UnListenFn
+  isProfileBlocked: (userId: string) => boolean
   dispose: () => void
 }
 
@@ -48,6 +51,7 @@ export const createOrGetAvatarsTracker = (): AvatarTracker => {
     onLeaveScene: []
   }
   const avatarProxies = new Map<string, Entity>()
+  const blockedProfiles = new Set<string>()
 
   for (const [playerEntity, data] of engine.getEntitiesWith(
     PlayerIdentityData
@@ -59,8 +63,7 @@ export const createOrGetAvatarsTracker = (): AvatarTracker => {
     ) {
       const proxy = createAvatarProxy(
         playerIdentity.address,
-        playerEntity,
-        `Show Profile`
+        playerEntity
       )
       avatarProxies.set(playerIdentity.address, proxy)
     }
@@ -82,8 +85,7 @@ export const createOrGetAvatarsTracker = (): AvatarTracker => {
     if (!avatarProxies.has(player.userId) && playerEntity) {
       const proxy = createAvatarProxy(
         player.userId,
-        playerEntity,
-        'Show Profile'
+        playerEntity
       )
       avatarProxies.set(player.userId, proxy)
     }
@@ -123,9 +125,40 @@ export const createOrGetAvatarsTracker = (): AvatarTracker => {
     }
   })
 
+  let modifierTimer = 0
+  engine.addSystem((dt) => {
+    modifierTimer += dt
+    if (modifierTimer < 1.0) return
+    modifierTimer = 0
+    executeTask(async () => {
+      const modifiers = await BevyApi.getAvatarModifiers()
+      const newBlocked = new Set<string>()
+      for (const entry of modifiers) {
+        if (entry.hideProfile) {
+          newBlocked.add(entry.userId)
+        }
+      }
+
+      for (const [userId, entity] of avatarProxies.entries()) {
+        const wasBlocked = blockedProfiles.has(userId)
+        const isBlocked = newBlocked.has(userId)
+        if (wasBlocked !== isBlocked) {
+          pointerEventsSystem.removeOnPointerDown(entity)
+          registerPointerDown(userId, entity, isBlocked)
+        }
+      }
+
+      blockedProfiles.clear()
+      for (const id of newBlocked) {
+        blockedProfiles.add(id)
+      }
+    })
+  })
+
   avatarTracker = {
     onClick,
     dispose,
+    isProfileBlocked: (userId: string) => blockedProfiles.has(userId),
     onEnterScene: (fn: PlayerCallback) => {
       callbacks.onEnterScene.push(fn)
       return () => {
@@ -155,26 +188,33 @@ export const createOrGetAvatarsTracker = (): AvatarTracker => {
     }
   }
 
-  function createAvatarProxy(
+  function registerPointerDown(
     userId: string,
-    playerEntity: Entity,
-    hoverText?: string
-  ): Entity {
+    entity: Entity,
+    blocked: boolean
+  ): void {
     pointerEventsSystem.onPointerDown(
       {
-        entity: playerEntity,
+        entity,
         opts: {
           button: InputAction.IA_POINTER,
-          hoverText
+          hoverText: blocked ? undefined : 'Show Profile',
+          showFeedback: !blocked
         }
       },
-      (event: PBPointerEventsResult) => {
+      (_event: PBPointerEventsResult) => {
         callbacks.onClick.forEach((fn) => {
           ;(fn as UserIdCallback)(userId)
         })
       }
     )
+  }
 
+  function createAvatarProxy(
+    userId: string,
+    playerEntity: Entity
+  ): Entity {
+    registerPointerDown(userId, playerEntity, false)
     return playerEntity
   }
 }

--- a/scene/src/ui-classes/main-hud/passport/profile-popup.tsx
+++ b/scene/src/ui-classes/main-hud/passport/profile-popup.tsx
@@ -47,7 +47,7 @@ export function setupProfilePopups(): void {
   const avatarTracker = createOrGetAvatarsTracker()
   avatarTracker.onClick((userId) => {
     if (!getPlayer({ userId })?.isGuest) {
-      // TODO AvatarModifierType.AMT_DISABLE_PASSPORTS
+      if (avatarTracker.isProfileBlocked(userId)) return
 
       PointerLock.getMutable(engine.CameraEntity).isPointerLocked = false
       store.dispatch(


### PR DESCRIPTION
## Summary
- Polls the engine's `getAvatarModifiers` API (every 1s) to track which avatars have profile interactions disabled by `AvatarModifierArea` with `AMT_DISABLE_PASSPORTS`
- Dynamically re-registers pointer events on avatar proxies to suppress hover tooltips (`showFeedback: false`) when blocked
- Blocks profile popup clicks via synchronous `isProfileBlocked` check on the avatar tracker

**Depends on:** https://github.com/decentraland/bevy-explorer/pull/677

🤖 Generated with [Claude Code](https://claude.com/claude-code)