### PR TITLE
fix: route /goto main and /world main to the EA realm provider

### DIFF
--- a/scene/src/ui-classes/main-hud/chat-and-logs/ChatsAndLogs.tsx
+++ b/scene/src/ui-classes/main-hud/chat-and-logs/ChatsAndLogs.tsx
@@ -452,7 +452,7 @@ function sendChatMessage(value: string): void {
             value.trim() === '/goto main'
           ) {
             await changeRealm({
-              realm: 'https://realm-provider.decentraland.org/main'
+              realm: 'https://realm-provider-ea.decentraland.org/main'
             })
             await sleep(1000)
             await teleportTo({
@@ -511,7 +511,7 @@ build: ${COMMIT_HASH}`,
           const [, world] = value.trim().split(' ')
           if (world === 'genesis' || world === 'main') {
             await changeRealm({
-              realm: 'https://realm-provider.decentraland.org/main'
+              realm: 'https://realm-provider-ea.decentraland.org/main'
             })
             await sleep(1000)
             await teleportTo({


### PR DESCRIPTION
## Summary
- The hardcoded `https://realm-provider.decentraland.org/main` URL used by `/goto main`, `/goto genesis`, `/world main`, and `/world genesis` is out of network for the social service. Switching to it caused friends to see the player as offline whenever they used those commands.
- Updated both call sites in `ChatsAndLogs.tsx` to `realm-provider-ea.decentraland.org/main`, which is in the same network the social service observes.