### PR TITLE
Proximity tooltips

### DIFF
--- a/scene/src/bevy-api/interface.ts
+++ b/scene/src/bevy-api/interface.ts
@@ -141,6 +141,22 @@ export type SystemHoverEvent = {
   actions: Array<PBPointerEvents_Entry & { enabled: boolean }>
 }
 
+export type Vec3 = { x: number; y: number; z: number }
+export type Vec2 = { x: number; y: number }
+
+export type SystemProximityEvent = {
+  entered: boolean
+  /** Session-stable opaque id; matches enter/leave for the same entity. */
+  entity: number
+  /**
+   * Entity transform origin in world space. The scene projects this to screen
+   * space per frame via its own helper using cached camera FOV (from
+   * `Runtime.getCameraFov`) and the live `Transform.get(engine.CameraEntity)`.
+   */
+  entityPosition: Vec3
+  actions: Array<PBPointerEvents_Entry & { enabled: boolean }>
+}
+
 export type ShowUiRequestParams = {
   hash?: string | undefined
   show?: boolean | undefined
@@ -191,6 +207,7 @@ export type BevyApiInterface = {
   getRealmProvider: () => Promise<string>
   getSystemActionStream: () => Promise<SystemAction[]>
   getHoverStream: () => Promise<SystemHoverEvent[]>
+  getProximityStream: () => Promise<SystemProximityEvent[]>
   getInputBindings: () => Promise<BindingsConfig>
   getChatStream: () => Promise<ChatMessageDefinition[]>
   getVoiceStream: () => Promise<MicActivation[]>

--- a/scene/src/bevy-api/interface.ts
+++ b/scene/src/bevy-api/interface.ts
@@ -149,9 +149,12 @@ export type SystemProximityEvent = {
   /** Session-stable opaque id; matches enter/leave for the same entity. */
   entity: number
   /**
-   * Entity transform origin in world space. The scene projects this to screen
-   * space per frame via its own helper using cached camera FOV (from
-   * `Runtime.getCameraFov`) and the live `Transform.get(engine.CameraEntity)`.
+   * World-space AABB centre of the specific collider on the entity that
+   * produced the closest-point hit. For multi-collider entities (e.g.
+   * GltfContainers) this anchors UI on the part the player is actually
+   * nearest. The scene projects it to screen space per frame via its own
+   * helper using cached camera FOV (from `Runtime.getCameraFov`) and the
+   * live `Transform.get(engine.CameraEntity)`.
    */
   entityPosition: Vec3
   actions: Array<PBPointerEvents_Entry & { enabled: boolean }>

--- a/scene/src/components/proximity-actions/proximity-action-component.tsx
+++ b/scene/src/components/proximity-actions/proximity-action-component.tsx
@@ -1,6 +1,12 @@
 import { ReactEcs, type ReactElement, UiEntity } from '@dcl/react-ecs'
 import { type SystemProximityEvent } from '../../bevy-api/interface'
-import { engine, executeTask, UiCanvasInformation } from '@dcl/sdk/ecs'
+import {
+  engine,
+  executeTask,
+  inputSystem,
+  PointerEventType,
+  UiCanvasInformation
+} from '@dcl/sdk/ecs'
 import { type Key } from '@dcl/sdk/react-ecs'
 import { BevyApi } from '../../bevy-api'
 import { COLOR } from '../color-palette'
@@ -82,9 +88,22 @@ function ProximityTooltip({
   event: SystemProximityEvent
   key?: Key
 }): ReactElement | null {
-  const actions = event.actions.filter(
-    (a) => a.eventInfo?.showFeedback !== false
-  )
+  // Match hover-action-component: pre-press, surface PET_DOWN entries (the
+  // "press X to do Y" prompts); while the entry's button is held, surface the
+  // matching PET_UP entry. Drag events drive the drag mechanics — scene
+  // authors get drag tooltips by pairing PetDown + PetDrag (or PetUp +
+  // PetDragEnd).
+  const actions = event.actions
+    .filter((a) => a.eventInfo?.showFeedback !== false)
+    .filter((a) => {
+      if (
+        a.eventInfo?.button !== undefined &&
+        inputSystem.isPressed(a.eventInfo?.button)
+      ) {
+        return a.eventType === PointerEventType.PET_UP
+      }
+      return a.eventType === PointerEventType.PET_DOWN
+    })
   if (actions.length === 0) return null
 
   const projection = projectWorldToScreen(event.entityPosition)

--- a/scene/src/components/proximity-actions/proximity-action-component.tsx
+++ b/scene/src/components/proximity-actions/proximity-action-component.tsx
@@ -33,8 +33,8 @@ const TOOLTIP_EDGE_MARGIN = 8
 // off-viewport / behind-camera entities.
 export const ProximityActionComponent = (): ReactElement | null => {
   const [activeEntities, setActiveEntities] = useState<
-    Record<string, SystemProximityEvent>
-  >({})
+    Map<string, SystemProximityEvent>
+  >(new Map())
 
   useEffect(() => {
     startCameraProjection()
@@ -43,12 +43,12 @@ export const ProximityActionComponent = (): ReactElement | null => {
         const stream = await BevyApi.getProximityStream()
         for await (const ev of stream) {
           setActiveEntities((prev) => {
-            const next = { ...prev }
+            const next = new Map(prev)
             const key = String(ev.entity)
             if (ev.entered) {
-              next[key] = ev
+              next.set(key, ev)
             } else {
-              delete next[key]
+              next.delete(key)
             }
             return next
           })
@@ -59,8 +59,8 @@ export const ProximityActionComponent = (): ReactElement | null => {
     })
   }, [])
 
-  const events = Object.values(activeEntities)
-  if (events.length === 0) return null
+  if (activeEntities.size === 0) return null
+  const events = Array.from(activeEntities.values())
 
   return (
     <UiEntity
@@ -118,10 +118,13 @@ function ProximityTooltip({
   const iconSize = fontSize * 2
 
   // Estimate tooltip dimensions so we can center on the anchor.
-  const rowWidth = (a: PBPointerEvents_Entry & { enabled: boolean }): number => {
+  const rowWidth = (
+    a: PBPointerEvents_Entry & { enabled: boolean }
+  ): number => {
     const text = a.eventInfo?.hoverText ?? 'Interact'
     const button = a.eventInfo?.button
-    const hasIcon = button !== undefined && inputBindings?.[button] !== undefined
+    const hasIcon =
+      button !== undefined && inputBindings?.[button] !== undefined
     const iconW = hasIcon ? iconSize + fontSize * 0.3 : 0
     return iconW + text.length * fontSize * APPROX_CHAR_WIDTH_RATIO
   }
@@ -136,7 +139,10 @@ function ProximityTooltip({
   // Constrain to the system-scene-set interactable area so tooltips don't sit
   // under the HUD or in the unsafe-area edges.
   const canvas = UiCanvasInformation.getOrNull(engine.RootEntity)
-  if (canvas?.interactableArea !== undefined && canvas.interactableArea !== null) {
+  if (
+    canvas?.interactableArea !== undefined &&
+    canvas.interactableArea !== null
+  ) {
     const ia = canvas.interactableArea
     const minLeft = ia.left + TOOLTIP_EDGE_MARGIN
     const minTop = ia.top + TOOLTIP_EDGE_MARGIN

--- a/scene/src/components/proximity-actions/proximity-action-component.tsx
+++ b/scene/src/components/proximity-actions/proximity-action-component.tsx
@@ -1,0 +1,198 @@
+import { ReactEcs, type ReactElement, UiEntity } from '@dcl/react-ecs'
+import { type SystemProximityEvent } from '../../bevy-api/interface'
+import { engine, executeTask, UiCanvasInformation } from '@dcl/sdk/ecs'
+import { type Key } from '@dcl/sdk/react-ecs'
+import { BevyApi } from '../../bevy-api'
+import { COLOR } from '../color-palette'
+import { MAX_ZINDEX } from '../../utils/constants'
+import { getFontSize } from '../../service/fontsize-system'
+import { getSceneInputBindingsMap } from '../../service/input-bindings'
+import {
+  projectWorldToScreen,
+  startCameraProjection
+} from '../../service/camera-projection'
+import { KeyIcon } from '../hover-actions/hover-action-component'
+import { getViewportHeight } from '../../service/canvas-ratio'
+import { type PBPointerEvents_Entry } from '@dcl/ecs'
+import useEffect = ReactEcs.useEffect
+import useState = ReactEcs.useState
+
+// Margin inside the interactable area used to keep tooltip anchors away from
+// the area's edges. Tweak here for visual feel.
+const TOOLTIP_EDGE_MARGIN = 8
+
+// Subscriber that surfaces the proximity stream as a screen-anchored tooltip
+// per in-range entity. Re-projects the entity world position on every render
+// so tooltips track camera movement, with a direction-based edge fallback for
+// off-viewport / behind-camera entities.
+export const ProximityActionComponent = (): ReactElement | null => {
+  const [activeEntities, setActiveEntities] = useState<
+    Record<string, SystemProximityEvent>
+  >({})
+
+  useEffect(() => {
+    startCameraProjection()
+    executeTask(async () => {
+      try {
+        const stream = await BevyApi.getProximityStream()
+        for await (const ev of stream) {
+          setActiveEntities((prev) => {
+            const next = { ...prev }
+            const key = String(ev.entity)
+            if (ev.entered) {
+              next[key] = ev
+            } else {
+              delete next[key]
+            }
+            return next
+          })
+        }
+      } catch (err) {
+        console.error('proximity stream error', err)
+      }
+    })
+  }, [])
+
+  const events = Object.values(activeEntities)
+  if (events.length === 0) return null
+
+  return (
+    <UiEntity
+      uiTransform={{
+        positionType: 'absolute',
+        width: '100%',
+        height: '100%',
+        zIndex: MAX_ZINDEX - 1
+      }}
+    >
+      {events.map((ev) => (
+        <ProximityTooltip key={String(ev.entity)} event={ev} />
+      ))}
+    </UiEntity>
+  )
+}
+
+// Rough character width used to estimate tooltip width for centering. DCL UI
+// has no measurement API, so we approximate; minor under/overshoot is fine.
+const APPROX_CHAR_WIDTH_RATIO = 0.55
+
+function ProximityTooltip({
+  event
+}: {
+  event: SystemProximityEvent
+  key?: Key
+}): ReactElement | null {
+  const actions = event.actions.filter(
+    (a) => a.eventInfo?.showFeedback !== false
+  )
+  if (actions.length === 0) return null
+
+  const projection = projectWorldToScreen(event.entityPosition)
+  if (projection === null) return null
+
+  const fontSize = getFontSize({})
+  const inputBindings = getSceneInputBindingsMap()
+  // Match hover tooltip styling: padding/border-radius scaled to viewport so
+  // tooltips look consistent across resolutions.
+  const padding = getViewportHeight() * 0.01
+  const borderRadius = getViewportHeight() * 0.01
+  const iconSize = fontSize * 2
+
+  // Estimate tooltip dimensions so we can center on the anchor.
+  const rowWidth = (a: PBPointerEvents_Entry & { enabled: boolean }): number => {
+    const text = a.eventInfo?.hoverText ?? 'Interact'
+    const button = a.eventInfo?.button
+    const hasIcon = button !== undefined && inputBindings?.[button] !== undefined
+    const iconW = hasIcon ? iconSize + fontSize * 0.3 : 0
+    return iconW + text.length * fontSize * APPROX_CHAR_WIDTH_RATIO
+  }
+  const widestRow = Math.max(...actions.map(rowWidth))
+  const estimatedWidth = padding * 2 + widestRow
+  const rowHeight = Math.max(iconSize, fontSize) + fontSize * 0.1
+  const estimatedHeight = padding * 2 + actions.length * rowHeight
+
+  let left = projection.x - estimatedWidth / 2
+  let top = projection.y - estimatedHeight / 2
+
+  // Constrain to the system-scene-set interactable area so tooltips don't sit
+  // under the HUD or in the unsafe-area edges.
+  const canvas = UiCanvasInformation.getOrNull(engine.RootEntity)
+  if (canvas?.interactableArea !== undefined && canvas.interactableArea !== null) {
+    const ia = canvas.interactableArea
+    const minLeft = ia.left + TOOLTIP_EDGE_MARGIN
+    const minTop = ia.top + TOOLTIP_EDGE_MARGIN
+    const maxLeft = Math.max(
+      minLeft,
+      canvas.width - ia.right - TOOLTIP_EDGE_MARGIN - estimatedWidth
+    )
+    const maxTop = Math.max(
+      minTop,
+      canvas.height - ia.bottom - TOOLTIP_EDGE_MARGIN - estimatedHeight
+    )
+    left = Math.min(Math.max(left, minLeft), maxLeft)
+    top = Math.min(Math.max(top, minTop), maxTop)
+  }
+
+  return (
+    <UiEntity
+      uiTransform={{
+        positionType: 'absolute',
+        position: { left, top },
+        padding,
+        borderRadius,
+        borderWidth: 0,
+        borderColor: COLOR.BLACK_TRANSPARENT,
+        flexDirection: 'column'
+      }}
+      uiBackground={{ color: COLOR.DARK_OPACITY_7 }}
+    >
+      {actions.map((action, i) => (
+        <ProximityActionRow
+          key={i}
+          action={action}
+          inputBindings={inputBindings}
+          fontSize={fontSize}
+        />
+      ))}
+    </UiEntity>
+  )
+}
+
+function ProximityActionRow({
+  action,
+  inputBindings,
+  fontSize
+}: {
+  action: PBPointerEvents_Entry & { enabled: boolean }
+  inputBindings: ReturnType<typeof getSceneInputBindingsMap>
+  fontSize: number
+  key?: Key
+}): ReactElement {
+  const button = action.eventInfo?.button
+  const binding =
+    button !== undefined && inputBindings?.[button] !== undefined
+      ? inputBindings[button]
+      : undefined
+  const text = action.eventInfo?.hoverText ?? 'Interact'
+
+  return (
+    <UiEntity
+      uiTransform={{
+        flexDirection: 'row',
+        alignItems: 'center'
+      }}
+    >
+      {binding !== undefined && <KeyIcon inputBinding={binding} />}
+      <UiEntity
+        uiTransform={{
+          margin: { left: binding !== undefined ? fontSize * 0.3 : 0 }
+        }}
+        uiText={{
+          value: text,
+          fontSize,
+          textWrap: 'nowrap'
+        }}
+      />
+    </UiEntity>
+  )
+}

--- a/scene/src/components/proximity-actions/proximity-action-component.tsx
+++ b/scene/src/components/proximity-actions/proximity-action-component.tsx
@@ -94,6 +94,7 @@ function ProximityTooltip({
   // authors get drag tooltips by pairing PetDown + PetDrag (or PetUp +
   // PetDragEnd).
   const actions = event.actions
+    .filter((a) => a.enabled)
     .filter((a) => a.eventInfo?.showFeedback !== false)
     .filter((a) => {
       if (
@@ -133,8 +134,8 @@ function ProximityTooltip({
   const rowHeight = Math.max(iconSize, fontSize) + fontSize * 0.1
   const estimatedHeight = padding * 2 + actions.length * rowHeight
 
-  let left = projection.x - estimatedWidth / 2
-  let top = projection.y - estimatedHeight / 2
+  let left = projection.left - estimatedWidth / 2
+  let top = projection.top - estimatedHeight / 2
 
   // Constrain to the system-scene-set interactable area so tooltips don't sit
   // under the HUD or in the unsafe-area edges.

--- a/scene/src/controllers/ui.controller.tsx
+++ b/scene/src/controllers/ui.controller.tsx
@@ -42,6 +42,7 @@ import { engine, PointerLock, Transform } from '@dcl/sdk/ecs'
 import { getViewportWidth } from '../service/canvas-ratio'
 import { listenSystemAction } from '../service/system-actions-emitter'
 import { HoverActionComponent } from '../components/hover-actions/hover-action-component'
+import { ProximityActionComponent } from '../components/proximity-actions/proximity-action-component'
 import { SceneLoadingWindowComponent } from '../components/scene-loading-window'
 import {
   applyGuestDisabledFeatures,
@@ -178,6 +179,7 @@ export class UIController {
         {getFeatureFlag(FEATURES.NOTIFICATIONS) && NotificationToastStack()}
         {PopupStack()}
         <HoverActionComponent />
+        <ProximityActionComponent />
         {SceneLoadingWindowComponent()}
       </Canvas>
     )

--- a/scene/src/service/camera-projection.ts
+++ b/scene/src/service/camera-projection.ts
@@ -1,0 +1,130 @@
+import {
+  engine,
+  executeTask,
+  Transform,
+  UiCanvasInformation
+} from '@dcl/sdk/ecs'
+import { Quaternion, Vector3 } from '@dcl/sdk/math'
+import { rotateVec3ByQuat } from './perspective-to-screen'
+
+// `~system/Runtime` doesn't ship `getCameraFov` in its bundled types; the op is
+// added by bevy-explorer (mirroring `getWorldTime`). Augment the module so we
+// can import it with proper typing.
+declare module '~system/Runtime' {
+  export function getCameraFov(): Promise<number>
+}
+
+// FOV is pushed via `GlobalCrdtState` whenever it changes and at least every
+// two seconds. We cache the latest value here and refresh on a slow timer; the
+// op is async, so we can't read it synchronously in the render path. Stale
+// readings are bounded by the bevy-side push cadence.
+let cachedFovY: number | null = null
+
+async function refreshCameraFov(): Promise<void> {
+  try {
+    const { getCameraFov } = await import('~system/Runtime')
+    const fov = await getCameraFov()
+    if (Number.isFinite(fov) && fov > 0) {
+      cachedFovY = fov
+    }
+  } catch (err) {
+    console.error('failed to read camera fov', err)
+  }
+}
+
+let started = false
+export function startCameraProjection(): void {
+  if (started) return
+  started = true
+  // Initial fetch + periodic refresh. Bevy already sends every two seconds on
+  // its side; this keeps our cache aligned even if a push was missed.
+  executeTask(async () => {
+    await refreshCameraFov()
+  })
+  let elapsed = 0
+  engine.addSystem((dt: number) => {
+    elapsed += dt
+    if (elapsed >= 1.5) {
+      elapsed = 0
+      void refreshCameraFov()
+    }
+  })
+}
+
+export type ScreenProjection =
+  | { kind: 'on-screen'; x: number; y: number }
+  | { kind: 'edge'; x: number; y: number }
+
+/**
+ * Project a world-space point to viewport pixel coords using the cached
+ * camera FOV plus the live player camera transform. Returns:
+ *
+ * - `on-screen` (with x,y inside viewport) when the point is in front of the
+ *   camera and within the canvas.
+ * - `edge` (with x,y on the viewport rectangle) for points off-viewport or
+ *   behind the camera — picked by intersecting the camera-space xy direction
+ *   with the canvas rect, so callers can pin a "pointer over there" indicator.
+ *
+ * Returns `null` until the FOV cache has been populated (very first frames).
+ */
+export function projectWorldToScreen(world: Vector3): ScreenProjection | null {
+  if (cachedFovY === null) return null
+  const camT = Transform.getOrNull(engine.CameraEntity)
+  if (camT === null) return null
+  const canvas = UiCanvasInformation.getOrNull(engine.RootEntity)
+  if (canvas === null || canvas.width <= 0 || canvas.height <= 0) return null
+
+  const camPos = camT.position
+  const camRot = camT.rotation as Quaternion
+
+  // World → camera space. DCL convention: camera looks down +Z (forward = +Z).
+  const rel = Vector3.create(
+    world.x - camPos.x,
+    world.y - camPos.y,
+    world.z - camPos.z
+  )
+  const inv = Quaternion.create(-camRot.x, -camRot.y, -camRot.z, camRot.w)
+  const cam = rotateVec3ByQuat(rel, inv)
+
+  const halfW = canvas.width * 0.5
+  const halfH = canvas.height * 0.5
+  const aspect = canvas.width / canvas.height
+  const tanHalf = Math.tan(cachedFovY * 0.5)
+
+  if (cam.z > 1e-4) {
+    // In front of camera — perspective project.
+    const ndcX = cam.x / (cam.z * tanHalf * aspect)
+    const ndcY = cam.y / (cam.z * tanHalf)
+    const x = (ndcX + 1) * 0.5 * canvas.width
+    const y = (1 - (ndcY + 1) * 0.5) * canvas.height
+    if (x >= 0 && x <= canvas.width && y >= 0 && y <= canvas.height) {
+      return { kind: 'on-screen', x, y }
+    }
+    // Off-viewport but in front: clamp the perspective projection to the
+    // viewport rect rather than shooting off to infinity.
+    return {
+      kind: 'edge',
+      x: Math.min(Math.max(x, 0), canvas.width),
+      y: Math.min(Math.max(y, 0), canvas.height)
+    }
+  }
+
+  // Behind the camera — fall back to direction-only edge projection.
+  // Camera-space y is up; viewport y is top-down, so flip y.
+  const xy2 = { x: cam.x, y: cam.y }
+  const len2 = xy2.x * xy2.x + xy2.y * xy2.y
+  if (len2 < 1e-6) {
+    return { kind: 'edge', x: halfW, y: halfH }
+  }
+  const len = Math.sqrt(len2)
+  const nx = xy2.x / len
+  const ny = xy2.y / len
+  const sx = nx !== 0 ? halfW / Math.abs(nx) : Number.POSITIVE_INFINITY
+  const sy = ny !== 0 ? halfH / Math.abs(ny) : Number.POSITIVE_INFINITY
+  const scale = Math.min(sx, sy)
+  return {
+    kind: 'edge',
+    x: halfW + nx * scale,
+    y: halfH - ny * scale
+  }
+}

--- a/scene/src/service/camera-projection.ts
+++ b/scene/src/service/camera-projection.ts
@@ -4,8 +4,8 @@ import {
   Transform,
   UiCanvasInformation
 } from '@dcl/sdk/ecs'
-import { Quaternion, Vector3 } from '@dcl/sdk/math'
-import { rotateVec3ByQuat } from './perspective-to-screen'
+import { type Quaternion, type Vector3 } from '@dcl/sdk/math'
+import { worldToScreenPx } from './perspective-to-screen'
 
 // `~system/Runtime` doesn't ship `getCameraFov` in its bundled types; the op is
 // added by bevy-explorer (mirroring `getWorldTime`). Augment the module so we
@@ -51,80 +51,34 @@ export function startCameraProjection(): void {
   })
 }
 
-export type ScreenProjection =
-  | { kind: 'on-screen'; x: number; y: number }
-  | { kind: 'edge'; x: number; y: number }
-
 /**
  * Project a world-space point to viewport pixel coords using the cached
- * camera FOV plus the live player camera transform. Returns:
+ * player camera FOV plus the live `engine.CameraEntity` transform. Returns:
  *
- * - `on-screen` (with x,y inside viewport) when the point is in front of the
- *   camera and within the canvas.
- * - `edge` (with x,y on the viewport rectangle) for points off-viewport or
- *   behind the camera — picked by intersecting the camera-space xy direction
- *   with the canvas rect, so callers can pin a "pointer over there" indicator.
+ * - in-front + on-viewport: `onScreen: true`, `left`/`top` inside the rect.
+ * - in-front + off-viewport: `onScreen: false`, `left`/`top` clamped to rect.
+ * - behind camera: `behind: true`, `left`/`top` placed on the rect edge in
+ *   the camera-space xy direction (a "pointer over there" indicator).
  *
- * Returns `null` until the FOV cache has been populated (very first frames).
+ * Returns `null` until the FOV cache is populated (first frames after load),
+ * or when the canvas has no size yet.
  */
-export function projectWorldToScreen(world: Vector3): ScreenProjection | null {
+export function projectWorldToScreen(
+  world: Vector3
+): { left: number; top: number; onScreen: boolean; behind: boolean } | null {
   if (cachedFovY === null) return null
   const camT = Transform.getOrNull(engine.CameraEntity)
   if (camT === null) return null
   const canvas = UiCanvasInformation.getOrNull(engine.RootEntity)
   if (canvas === null || canvas.width <= 0 || canvas.height <= 0) return null
 
-  const camPos = camT.position
-  const camRot = camT.rotation as Quaternion
-
-  // World → camera space. DCL convention: camera looks down +Z (forward = +Z).
-  const rel = Vector3.create(
-    world.x - camPos.x,
-    world.y - camPos.y,
-    world.z - camPos.z
+  return worldToScreenPx(
+    world,
+    camT.position,
+    camT.rotation as Quaternion,
+    cachedFovY,
+    canvas.width,
+    canvas.height,
+    { boundOutOfScreen: true }
   )
-  const inv = Quaternion.create(-camRot.x, -camRot.y, -camRot.z, camRot.w)
-  const cam = rotateVec3ByQuat(rel, inv)
-
-  const halfW = canvas.width * 0.5
-  const halfH = canvas.height * 0.5
-  const aspect = canvas.width / canvas.height
-  const tanHalf = Math.tan(cachedFovY * 0.5)
-
-  if (cam.z > 1e-4) {
-    // In front of camera — perspective project.
-    const ndcX = cam.x / (cam.z * tanHalf * aspect)
-    const ndcY = cam.y / (cam.z * tanHalf)
-    const x = (ndcX + 1) * 0.5 * canvas.width
-    const y = (1 - (ndcY + 1) * 0.5) * canvas.height
-    if (x >= 0 && x <= canvas.width && y >= 0 && y <= canvas.height) {
-      return { kind: 'on-screen', x, y }
-    }
-    // Off-viewport but in front: clamp the perspective projection to the
-    // viewport rect rather than shooting off to infinity.
-    return {
-      kind: 'edge',
-      x: Math.min(Math.max(x, 0), canvas.width),
-      y: Math.min(Math.max(y, 0), canvas.height)
-    }
-  }
-
-  // Behind the camera — fall back to direction-only edge projection.
-  // Camera-space y is up; viewport y is top-down, so flip y.
-  const xy2 = { x: cam.x, y: cam.y }
-  const len2 = xy2.x * xy2.x + xy2.y * xy2.y
-  if (len2 < 1e-6) {
-    return { kind: 'edge', x: halfW, y: halfH }
-  }
-  const len = Math.sqrt(len2)
-  const nx = xy2.x / len
-  const ny = xy2.y / len
-  const sx = nx !== 0 ? halfW / Math.abs(nx) : Number.POSITIVE_INFINITY
-  const sy = ny !== 0 ? halfH / Math.abs(ny) : Number.POSITIVE_INFINITY
-  const scale = Math.min(sx, sy)
-  return {
-    kind: 'edge',
-    x: halfW + nx * scale,
-    y: halfH - ny * scale
-  }
 }

--- a/scene/src/service/perspective-to-screen.ts
+++ b/scene/src/service/perspective-to-screen.ts
@@ -101,22 +101,32 @@ function verticalFovFrom(
 }
 
 type WorldToScreenOptions = {
-  /** Si true, fovRad es horizontal y se convierte a vertical internamente */
+  /** If true, fovRad is horizontal and is converted to vertical internally. */
   fovIsHorizontal?: boolean
-  /** En DCL/Unity el forward es +Z, así que por defecto false */
+  /** DCL/Unity uses +Z forward, so default false. */
   forwardIsNegZ?: boolean
+  /**
+   * When true, off-viewport and behind-camera points are clamped to the
+   * viewport rectangle: off-viewport perspective coords are clamped, and
+   * behind-camera points are projected from the camera-space xy direction
+   * onto the viewport rect (a "compass" indicator). `onScreen` and `behind`
+   * still report the underlying state. Default false — preserves the
+   * original "junk coords for behind-camera" shape, leaving callers to
+   * filter on `onScreen`.
+   */
+  boundOutOfScreen?: boolean
 }
 
 export function worldToScreenPx(
   world: Vector3,
   cameraPos: Vector3,
   cameraRot: Quaternion,
-  fovRad: number, // puede ser V u H según options.fovIsHorizontal
+  fovRad: number,
   viewportWidth: number,
   viewportHeight: number,
   options: WorldToScreenOptions = {}
-): { left: number; top: number; onScreen: boolean } {
-  const forwardIsNegZ = options.forwardIsNegZ ?? false // DCL/Unity: +Z forward
+): { left: number; top: number; onScreen: boolean; behind: boolean } {
+  const forwardIsNegZ = options.forwardIsNegZ ?? false
   const verticalFovRad = verticalFovFrom(
     fovRad,
     viewportWidth,
@@ -124,39 +134,62 @@ export function worldToScreenPx(
     !!options.fovIsHorizontal
   )
 
-  // vector relativo
   const rel = Vector3.create(
     world.x - cameraPos.x,
     world.y - cameraPos.y,
     world.z - cameraPos.z
   )
-
-  // inversa de la rotación: inv(q) = (-x,-y,-z,w)
   const inv = Quaternion.create(
     -cameraRot.x,
     -cameraRot.y,
     -cameraRot.z,
     cameraRot.w
   )
-
-  // pasamos al espacio cámara
   const cam = rotateVec3ByQuat(rel, inv)
 
   const aspect = viewportWidth / viewportHeight
   const tanHalf = Math.tan(verticalFovRad / 2)
-
+  const halfW = viewportWidth * 0.5
+  const halfH = viewportHeight * 0.5
   const depth = forwardIsNegZ ? -cam.z : cam.z
-  if (depth <= 0) return { top: -100, left: -100, onScreen: false } // detrás de la cámara
+  const behind = depth <= 1e-4
 
-  const ndcX = cam.x / (depth * tanHalf * aspect)
-  const ndcY = cam.y / (depth * tanHalf)
+  if (!behind) {
+    const ndcX = cam.x / (depth * tanHalf * aspect)
+    const ndcY = cam.y / (depth * tanHalf)
+    let left = (ndcX + 1) * 0.5 * viewportWidth
+    let top = (1 - (ndcY + 1) * 0.5) * viewportHeight
+    const onScreen =
+      left >= 0 && left <= viewportWidth && top >= 0 && top <= viewportHeight
+    if (options.boundOutOfScreen && !onScreen) {
+      left = Math.min(Math.max(left, 0), viewportWidth)
+      top = Math.min(Math.max(top, 0), viewportHeight)
+    }
+    return { left, top, onScreen, behind: false }
+  }
 
-  const left = Math.floor((ndcX + 1) * 0.5 * viewportWidth)
-  const top = Math.floor((1 - (ndcY + 1) * 0.5) * viewportHeight)
+  if (!options.boundOutOfScreen) {
+    return { left: -100, top: -100, onScreen: false, behind: true }
+  }
 
-  const onScreen =
-    left >= 0 && left <= viewportWidth && top >= 0 && top <= viewportHeight
-  return { left, top, onScreen }
+  // Compass-edge fallback: project the camera-space xy direction onto the
+  // viewport rect. cam.y is up, so flip y for the top-down viewport axis.
+  const len2 = cam.x * cam.x + cam.y * cam.y
+  if (len2 < 1e-6) {
+    return { left: halfW, top: halfH, onScreen: false, behind: true }
+  }
+  const len = Math.sqrt(len2)
+  const nx = cam.x / len
+  const ny = cam.y / len
+  const sx = nx !== 0 ? halfW / Math.abs(nx) : Number.POSITIVE_INFINITY
+  const sy = ny !== 0 ? halfH / Math.abs(ny) : Number.POSITIVE_INFINITY
+  const scale = Math.min(sx, sy)
+  return {
+    left: halfW + nx * scale,
+    top: halfH - ny * scale,
+    onScreen: false,
+    behind: true
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a screen-anchored tooltip per in-range proximity-aware entity, consuming the new `GetProximityStream` and `Runtime.getCameraFov` APIs added on the bevy side.

- `ProximityActionComponent` listens to `BevyApi.getProximityStream()` and tracks active entities by `event.entity`. Renders a `KeyIcon` + text row per action, matching the styling of the existing hover tooltips (rounded border, dark background, viewport-scaled padding).
- `service/camera-projection.ts` does world→screen projection per render: cached camera FOV (refreshed via `Runtime.getCameraFov` on a slow timer; bevy pushes on change and at least every 2s), live `Transform.get(engine.CameraEntity)`, viewport from `UiCanvasInformation`. Returns the projected pixel for on-screen entities, a clamped viewport-edge for off-screen-but-in-front entities, and a direction-based "compass" edge for behind-camera entities.
- Tooltip anchor is centred on the projected position (size estimated from text length + icon width, since DCL UI has no measurement API) and clamped inside `UiCanvasInformation.interactableArea` with an 8-px margin so tooltips don't sit under the HUD.
- Press-state filter mirrors `hover-action-component`: `PetDown` entries pre-press, `PetUp` entries while held. Drag entries don't surface — scene authors pair `PetDown` + `PetDrag` for "press and drag with X" patterns; the `PetDown` entry's `hover_text` carries the tooltip.

## Cross-dependency

Requires **decentraland/bevy-explorer#764** which exposes `GetProximityStream`, `Runtime.getCameraFov`, and the `ProximityEvent` payload this PR consumes. Without it the component renders nothing (the stream call returns no events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)