### PR TITLE
Add realm-disconnected prompt to scene loading UI

### DIFF
--- a/scene/src/bevy-api/interface.ts
+++ b/scene/src/bevy-api/interface.ts
@@ -181,6 +181,8 @@ export type BindingsConfig = {
 }
 export type SceneLoadingWindow = {
   visible: boolean
+  // Optional: older engines don't emit this. Absent is treated as connected.
+  realmConnected?: boolean
   title: string
   pendingAssets: number | null
 }

--- a/scene/src/components/scene-loading-window.tsx
+++ b/scene/src/components/scene-loading-window.tsx
@@ -7,6 +7,32 @@ import { getContentHeight } from '../service/canvas-ratio'
 import { getBackgroundFromAtlas } from '../utils/ui-utils'
 import { SpinnerLoading } from './spinner-loading'
 import { getFontSize } from 'src/service/fontsize-system'
+import { changeRealm } from '~system/RestrictedActions'
+import { getRealm } from '~system/Runtime'
+import { executeTask } from '@dcl/sdk/ecs'
+import { Color4 } from '@dcl/sdk/math'
+import { ButtonText } from './button-text'
+import {
+  ALMOST_BLACK,
+  CLICKED_PRIMARY_COLOR,
+  RUBY
+} from '../utils/constants'
+import useState = ReactEcs.useState
+import useEffect = ReactEcs.useEffect
+
+const GENESIS_CITY_REALM = 'https://realm-provider-ea.decentraland.org/main'
+
+// Don't flash the disconnected prompt during the initial connection on startup,
+// nor while a realm change requested from it is in flight.
+const DISCONNECT_PROMPT_GRACE_MS = 1000
+let suppressDisconnectPromptUntil = Date.now() + DISCONNECT_PROMPT_GRACE_MS
+function suppressDisconnectPrompt(): void {
+  suppressDisconnectPromptUntil = Date.now() + DISCONNECT_PROMPT_GRACE_MS
+}
+
+function normalizeRealm(realm: string | null | undefined): string {
+  return (realm ?? '').trim().toLowerCase().replace(/\/+$/, '')
+}
 
 export async function initSceneLoadingUi(): Promise<void> {
   const awaitSceneLoadingWindow = async (
@@ -18,7 +44,11 @@ export async function initSceneLoadingUi(): Promise<void> {
 
       store.dispatch(
         updateHudStateAction({
-          loadingScene: uiState
+          loadingScene: {
+            ...uiState,
+            // Older engines don't emit this field — assume connected.
+            realmConnected: uiState.realmConnected !== false
+          }
         })
       )
     }
@@ -30,6 +60,12 @@ export async function initSceneLoadingUi(): Promise<void> {
 
 export function SceneLoadingWindowComponent(): ReactElement | null {
   const loadingScene = store.getState().hud.loadingScene
+  // Only treat an explicit `false` as disconnected, so a missing field
+  // (older engine) is assumed connected.
+  if (loadingScene.realmConnected === false) {
+    if (Date.now() < suppressDisconnectPromptUntil) return null
+    return <RealmDisconnectedComponent />
+  }
   if (!loadingScene.visible) return null
 
   return (
@@ -78,6 +114,141 @@ export function SceneLoadingWindowComponent(): ReactElement | null {
           height: getContentHeight() * 0.1
         }}
       />
+    </UiEntity>
+  )
+}
+
+function RealmDisconnectedComponent(): ReactElement {
+  const [currentRealm, setCurrentRealm] = useState<string | null>(null)
+  const [retryBackground, setRetryBackground] = useState<Color4>(RUBY)
+  const [genesisBackground, setGenesisBackground] =
+    useState<Color4>(ALMOST_BLACK)
+  const fontSize = getFontSize({})
+
+  // RealmInfo carries the realm base URL even while disconnected (the engine
+  // keeps it pointed at the realm it's attempting), so retry can target it.
+  useEffect(() => {
+    executeTask(async () => {
+      try {
+        const realm = await getRealm({})
+        setCurrentRealm(realm.realmInfo?.baseUrl ?? null)
+      } catch (error) {
+        console.error(error)
+      }
+    })
+  }, [])
+
+  // Show Genesis unless we know we're already on it.
+  const showGenesis =
+    !currentRealm ||
+    normalizeRealm(currentRealm) !== normalizeRealm(GENESIS_CITY_REALM)
+
+  return (
+    <UiEntity
+      uiTransform={{
+        width: '100%',
+        height: '100%',
+        positionType: 'absolute',
+        position: 0,
+        pointerFilter: 'block',
+        justifyContent: 'center',
+        alignItems: 'center',
+        flexDirection: 'column'
+      }}
+      uiBackground={{
+        textureMode: 'stretch',
+        texture: {
+          src: 'assets/images/login/gradient-background.png'
+        }
+      }}
+    >
+      <UiEntity
+        uiTransform={{
+          width: getContentHeight() * 0.1,
+          height: getContentHeight() * 0.1
+        }}
+        uiBackground={{
+          textureMode: 'stretch',
+          ...getBackgroundFromAtlas({
+            spriteName: 'DdlIconColor',
+            atlasName: 'icons'
+          })
+        }}
+      />
+      <UiEntity
+        uiTransform={{
+          margin: { top: fontSize, bottom: fontSize * 1.5 },
+          width: getContentHeight() * 0.6
+        }}
+        uiText={{
+          value:
+            "<b>Couldn't connect to the realm</b>\nThe connection to the realm couldn't be established. Retry, or jump to Genesis City.",
+          fontSize
+        }}
+      />
+      <UiEntity
+        uiTransform={{
+          flexDirection: 'row',
+          justifyContent: 'center',
+          alignItems: 'center'
+        }}
+      >
+        <ButtonText
+          uiTransform={{
+            margin: fontSize * 0.3,
+            padding: fontSize * 0.3,
+            width: getContentHeight() * 0.25
+          }}
+          backgroundColor={retryBackground}
+          value={'RETRY'}
+          fontSize={fontSize}
+          onMouseEnter={() => {
+            setRetryBackground(CLICKED_PRIMARY_COLOR)
+          }}
+          onMouseLeave={() => {
+            setRetryBackground(RUBY)
+          }}
+          onMouseDown={() => {
+            if (!currentRealm) return
+            suppressDisconnectPrompt()
+            executeTask(async () => {
+              try {
+                await changeRealm({ realm: currentRealm })
+              } catch (error) {
+                console.error(error)
+              }
+            })
+          }}
+        />
+        {showGenesis && (
+          <ButtonText
+            uiTransform={{
+              margin: fontSize * 0.3,
+              padding: fontSize * 0.3,
+              width: getContentHeight() * 0.25
+            }}
+            backgroundColor={genesisBackground}
+            value={'GO TO\nGENESIS CITY'}
+            fontSize={fontSize}
+            onMouseEnter={() => {
+              setGenesisBackground(Color4.Gray())
+            }}
+            onMouseLeave={() => {
+              setGenesisBackground(ALMOST_BLACK)
+            }}
+            onMouseDown={() => {
+              suppressDisconnectPrompt()
+              executeTask(async () => {
+                try {
+                  await changeRealm({ realm: GENESIS_CITY_REALM })
+                } catch (error) {
+                  console.error(error)
+                }
+              })
+            }}
+          />
+        )}
+      </UiEntity>
     </UiEntity>
   )
 }

--- a/scene/src/components/scene-loading-window.tsx
+++ b/scene/src/components/scene-loading-window.tsx
@@ -12,11 +12,7 @@ import { getRealm } from '~system/Runtime'
 import { executeTask } from '@dcl/sdk/ecs'
 import { Color4 } from '@dcl/sdk/math'
 import { ButtonText } from './button-text'
-import {
-  ALMOST_BLACK,
-  CLICKED_PRIMARY_COLOR,
-  RUBY
-} from '../utils/constants'
+import { ALMOST_BLACK, CLICKED_PRIMARY_COLOR, RUBY } from '../utils/constants'
 import useState = ReactEcs.useState
 import useEffect = ReactEcs.useEffect
 

--- a/scene/src/state/hud/state.ts
+++ b/scene/src/state/hud/state.ts
@@ -233,6 +233,7 @@ export const hudInitialState: HudState = {
   micEnabled: false,
   loadingScene: {
     visible: false,
+    realmConnected: true,
     title: '',
     pendingAssets: null
   },


### PR DESCRIPTION
## Summary

Adds a prompt to the scene loading UI that appears when the loading stream reports the realm is not connected (`realmConnected === false`, a field recently added to the stream).

The prompt offers two actions:
- **RETRY** — change realm to the current realm (re-attempt the connection).
- **GO TO GENESIS CITY** — change realm to the EA realm provider (`https://realm-provider-ea.decentraland.org/main`). Hidden when already on that realm.

## Details

- The retry target is read from `getRealm().realmInfo.baseUrl`. The engine keeps `RealmInfo` pointed at the realm it's attempting even while disconnected, so this is reliable without any engine change.
- Buttons reuse the shared `ButtonText` component with login-style hover states.
- **Resilience:** a missing `realmConnected` field is treated as connected (optional type, `!== false` on ingest, `=== false` render guard, default state `true`), so older engines that don't emit it are unaffected.
- The prompt is suppressed for 1s after startup and after pressing a button, to avoid flashing during the initial connection or an in-flight realm change.