### PR TITLE
Disable shadow casting on 3D avatar nametags

### DIFF
--- a/scene/src/components/avatar-tags/avatar-name-tag-3d.tsx
+++ b/scene/src/components/avatar-tags/avatar-name-tag-3d.tsx
@@ -119,6 +119,7 @@ function createTag(player: GetPlayerDataRes): undefined | Entity {
 
   Material.setPbrMaterial(tagWrapperEntity, {
     transparencyMode: MaterialTransparencyMode.MTM_ALPHA_BLEND,
+    castShadows: false,
     texture: {
       tex: {
         $case: 'uiTexture',


### PR DESCRIPTION
## What

Sets `castShadows: false` on the PBR material used for the 3D avatar nametags (`avatar-name-tag-3d.tsx`).

## Why

Each nametag is a billboarded `MeshRenderer.setPlane` entity with a PBR material. In the bevy-explorer client, a material's `cast_shadows` flag defaults to `true` when unset, and the client only marks the quad `NotShadowCaster` when the material explicitly sets `cast_shadows = false`. As a result the nametag planes were casting shadows into the scene.

Setting `castShadows: false` makes the client mark the quad as a non-shadow-caster, so nametags no longer cast shadows.